### PR TITLE
Remove thepiratebay.now.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,8 +49,6 @@ Awesome list of `now.sh` deployments.
 
 * [snippets.now.sh](https://snippets.now.sh/) -> Sublime Text, Atom & VS Code snippet generator.
 
-* [thepiratebay.now.sh](https://thepiratebay.now.sh/) -> Proxy site for thepiratebay.org.
-
 * [onionite.now.sh](https://onionite.now.sh/) -> Explore the Tor network.
 
 * [domain.now.sh](https://domain.now.sh/) -> Check domain availability. 


### PR DESCRIPTION
Haven't received an official comment from ZEIT but I'm pretty sure this got my account banned. 😬

Either way, the deployment is down and I no longer have access to that alias so the service isn't active. It should be removed from the list.